### PR TITLE
Send connect op when reconnecting

### DIFF
--- a/src/nats_client/client.rs
+++ b/src/nats_client/client.rs
@@ -236,6 +236,10 @@ impl NatsClient {
                     *recon_client.control_tx.write() = control_tx;
                     *recon_client.state.write() = NatsClientState::Connected;
 
+                    if let Err(e) = NatsClient::connect(&recon_client).wait() {
+                        error!(target: "ratsio", "Failed to send connect op {:?}", e)
+                    }
+
                     if recon_opts.subscribe_on_reconnect {
                         let subs_sender = recon_client.sender.clone();
                         let subs_fut_list: Vec<_> = recon_subs_map.read().iter().map(|(_, sink)| {
@@ -460,11 +464,16 @@ impl NatsClient {
             .for_sid(sub_cmd.clone())
             .take(1)
             .into_future()
-            .map(move |(surely_message, _)| {
-                let msg = surely_message.unwrap();
-                receiver.read().remove_sid(&sid);
-                msg
-            }).map_err(|(e, _)| e);
+            .map_err(|(e, _)| e)
+            .and_then(move |(message, _)| {
+                match message {
+                    Some(m) => {
+                        receiver.read().remove_sid(&sid);
+                        Ok(m)
+                    },
+                    None => Err(RatsioError::InnerBrokenChain)
+                }
+            });
 
 
         Either::B(


### PR DESCRIPTION
It appears that the `CONNECT` op is not sent when reconnecting. This change sends the `CONNECT` op.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>