### PR TITLE
Update tokio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ thiserror           = "1"
 futures             = {version="^0.3"}
 futures-core        = "^0.3"
 futures-timer       = "^2.0"
-pin-project         = "^0.4"
+pin-project         = "1"
 
 tokio               = { version = "^1", features = ["rt-multi-thread", "net", "time", "io-util", "macros", "sync"] }
 tokio-util          = { version = "^0.6", features = ["codec"] }
 native-tls          = { version = "^0.2", optional = true }
 tokio-native-tls    = { version = "^0.3", optional = true }
 
-nom                 = {version = "^4.1", features = ["regexp", "verbose-errors"]}
+nom                 = { version = "^4.1", features = ["regexp", "verbose-errors"] }
 rand                = "^0.6"
 regex               = "^1.3"
 lazy_static         = "^1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes               = "^0.4"
-prost               = "^0.6"
+bytes               = "^1"
+prost               = "^0.7"
 log                 = "^0.4"
 cfg-if              = "^0.1"
 thiserror           = "1"
@@ -30,10 +30,10 @@ futures-core        = "^0.3"
 futures-timer       = "^2.0"
 pin-project         = "^0.4"
 
-tokio               = { version = "^0.2", features = ["io-util", "macros", "stream", "sync", "rt-core", "rt-threaded", "time", "tcp"] }
-tokio-util          = { version = "^0.2", features = ["codec"] }
+tokio               = { version = "^1", features = ["rt-multi-thread", "net", "time", "io-util", "macros", "sync"] }
+tokio-util          = { version = "^0.6", features = ["codec"] }
 native-tls          = { version = "^0.2", optional = true }
-tokio-tls           = { version = "^0.3", optional = true }
+tokio-native-tls    = { version = "^0.3", optional = true }
 
 nom                 = {version = "^4.1", features = ["regexp", "verbose-errors"]}
 rand                = "^0.6"
@@ -42,7 +42,7 @@ lazy_static         = "^1.2"
 derive_builder      = "^0.7"
 
 atomic-counter      = "^1.0"
-nkeys               = {version="^0.0.9", optional=true}
+nkeys               = { version="^0.1", optional=true }
 sha2                = "^0.9"
 
 data-encoding       = "^2.1.2"
@@ -50,11 +50,11 @@ env_logger = {version="^0.7"}
 
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.7"
 
 [dev-dependencies]
 ctrlc = "3.1"
 
 [features]
 default = ["tls"]
-tls = ["native-tls", "tokio-tls"]
+tls = ["native-tls", "tokio-native-tls"]


### PR DESCRIPTION
Update `tokio` version to 1.0+ along with related minor dependencies.
This also fixes the deprecation warning for using `pin-project` with enums.

No functionality should be affected but this needs a version bump to 0.4.0, since it breaks compatibility with dependents using the `tokio` 0.2 runtime.
